### PR TITLE
#15  Add support for other languages and plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,9 @@
                 <version>3.13</version>
                 <extensions>true</extensions>
                 <configuration>
+                    <publicPackages>
+                        <publicPackage>com.junichi11.netbeans.modules.color.codes.preview.colors.model</publicPackage>
+                    </publicPackages>
                     <codeNameBase>com.junichi11.netbeans.modules.color.codes.preview</codeNameBase>
                     <licenseName>Apache License, Version 2.0</licenseName>
                     <licenseFile>license.txt</licenseFile>

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/CssHSLAColorValue.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/CssHSLAColorValue.java
@@ -15,14 +15,17 @@
  */
 package com.junichi11.netbeans.modules.color.codes.preview.colors;
 
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.AbstractColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorType;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorsUtils;
 import java.awt.Color;
+import org.netbeans.api.annotations.common.NonNull;
 
-public class CssHSLAColorValue extends ColorValueImpl {
+public class CssHSLAColorValue extends AbstractColorValue {
 
-    public CssHSLAColorValue(String value, int startOffset, int endOffset, int line) {
-        super(value, startOffset, endOffset, line);
+    public CssHSLAColorValue(@NonNull ColorCodesProvider colorCodesProvider, String value, int startOffset, int endOffset, int line) {
+        super(colorCodesProvider, value, startOffset, endOffset, line);
     }
 
     @Override

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/CssHSLColorValue.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/CssHSLColorValue.java
@@ -15,14 +15,17 @@
  */
 package com.junichi11.netbeans.modules.color.codes.preview.colors;
 
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.AbstractColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorType;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorsUtils;
 import java.awt.Color;
+import org.netbeans.api.annotations.common.NonNull;
 
-public class CssHSLColorValue extends ColorValueImpl {
+public class CssHSLColorValue extends AbstractColorValue {
 
-    public CssHSLColorValue(String value, int startOffset, int endOffset, int line) {
-        super(value, startOffset, endOffset, line);
+    public CssHSLColorValue(@NonNull ColorCodesProvider colorCodesProvider, String value, int startOffset, int endOffset, int line) {
+        super(colorCodesProvider, value, startOffset, endOffset, line);
     }
 
     @Override

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/CssIntRGBAColorValue.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/CssIntRGBAColorValue.java
@@ -15,14 +15,17 @@
  */
 package com.junichi11.netbeans.modules.color.codes.preview.colors;
 
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.AbstractColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorType;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorsUtils;
 import java.awt.Color;
+import org.netbeans.api.annotations.common.NonNull;
 
-public class CssIntRGBAColorValue extends ColorValueImpl {
+public class CssIntRGBAColorValue extends AbstractColorValue {
 
-    public CssIntRGBAColorValue(String value, int startOffset, int endOffset, int line) {
-        super(value, startOffset, endOffset, line);
+    public CssIntRGBAColorValue(@NonNull ColorCodesProvider colorCodesProvider, String value, int startOffset, int endOffset, int line) {
+        super(colorCodesProvider, value, startOffset, endOffset, line);
     }
 
     @Override

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/CssIntRGBColorValue.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/CssIntRGBColorValue.java
@@ -15,14 +15,17 @@
  */
 package com.junichi11.netbeans.modules.color.codes.preview.colors;
 
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.AbstractColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorType;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorsUtils;
 import java.awt.Color;
+import org.netbeans.api.annotations.common.NonNull;
 
-public class CssIntRGBColorValue extends ColorValueImpl {
+public class CssIntRGBColorValue extends AbstractColorValue {
 
-    public CssIntRGBColorValue(String value, int startOffset, int endOffset, int line) {
-        super(value, startOffset, endOffset, line);
+    public CssIntRGBColorValue(@NonNull ColorCodesProvider colorCodesProvider, String value, int startOffset, int endOffset, int line) {
+        super(colorCodesProvider, value, startOffset, endOffset, line);
     }
 
     @Override

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/CssPercentRGBAColorValue.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/CssPercentRGBAColorValue.java
@@ -15,14 +15,17 @@
  */
 package com.junichi11.netbeans.modules.color.codes.preview.colors;
 
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.AbstractColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorType;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorsUtils;
 import java.awt.Color;
+import org.netbeans.api.annotations.common.NonNull;
 
-public class CssPercentRGBAColorValue extends ColorValueImpl {
+public class CssPercentRGBAColorValue extends AbstractColorValue {
 
-    public CssPercentRGBAColorValue(String value, int startOffset, int endOffset, int line) {
-        super(value, startOffset, endOffset, line);
+    public CssPercentRGBAColorValue(@NonNull ColorCodesProvider colorCodesProvider, String value, int startOffset, int endOffset, int line) {
+        super(colorCodesProvider, value, startOffset, endOffset, line);
     }
 
     @Override

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/HexColorValue.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/HexColorValue.java
@@ -15,14 +15,17 @@
  */
 package com.junichi11.netbeans.modules.color.codes.preview.colors;
 
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.AbstractColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorType;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorsUtils;
 import java.awt.Color;
+import org.netbeans.api.annotations.common.NonNull;
 
-public class HexColorValue extends ColorValueImpl {
+public class HexColorValue extends AbstractColorValue {
 
-    public HexColorValue(String value, int startOffset, int endOffset, int line) {
-        super(value, startOffset, endOffset, line);
+    public HexColorValue(@NonNull ColorCodesProvider colorCodesProvider, String value, int startOffset, int endOffset, int line) {
+        super(colorCodesProvider, value, startOffset, endOffset, line);
     }
 
     @Override

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/JavaIntRGBColorValue.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/JavaIntRGBColorValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 junichi11.
+ * Copyright 2019 arsi.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,29 +13,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.junichi11.netbeans.modules.color.codes.preview.colors;
 
 import com.junichi11.netbeans.modules.color.codes.preview.colors.model.AbstractColorValue;
 import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider;
-import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorType;
-import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorsUtils;
+import com.junichi11.netbeans.modules.color.codes.preview.utils.JavaColorType;
 import java.awt.Color;
 import org.netbeans.api.annotations.common.NonNull;
 
-public class CssPercentRGBColorValue extends AbstractColorValue {
+/**
+ *
+ * @author arsi
+ */
+public class JavaIntRGBColorValue extends AbstractColorValue {
 
-    public CssPercentRGBColorValue(@NonNull ColorCodesProvider colorCodesProvider, String value, int startOffset, int endOffset, int line) {
+    private int r;
+    private int g;
+    private int b;
+
+    public JavaIntRGBColorValue(@NonNull ColorCodesProvider colorCodesProvider, String value, int startOffset, int endOffset, int line, int r, int g, int b) {
         super(colorCodesProvider, value, startOffset, endOffset, line);
+        this.r = r;
+        this.g = g;
+        this.b = b;
     }
 
     @Override
     public Color getColor() {
-        return ColorsUtils.decode(getValue(), ColorType.CSS_PERCENT_RGB);
+        return new Color(r, g, b);
     }
 
     @Override
-    public ColorType getType() {
-        return ColorType.CSS_PERCENT_RGB;
+    public JavaColorType getType() {
+        return JavaColorType.JAVA_INT_RGB;
     }
 
 }

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/NamedColorValue.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/NamedColorValue.java
@@ -15,14 +15,17 @@
  */
 package com.junichi11.netbeans.modules.color.codes.preview.colors;
 
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.AbstractColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorType;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorsUtils;
 import java.awt.Color;
+import org.netbeans.api.annotations.common.NonNull;
 
-public class NamedColorValue extends ColorValueImpl {
+public class NamedColorValue extends AbstractColorValue {
 
-    public NamedColorValue(String value, int startOffset, int endOffset, int line) {
-        super(value, startOffset, endOffset, line);
+    public NamedColorValue(@NonNull ColorCodesProvider colorCodesProvider, String value, int startOffset, int endOffset, int line) {
+        super(colorCodesProvider, value, startOffset, endOffset, line);
     }
 
     @Override

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/AbstractColorValue.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/AbstractColorValue.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 junichi11.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.junichi11.netbeans.modules.color.codes.preview.colors.model;
+
+import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorsUtils;
+import java.awt.Color;
+import org.netbeans.api.annotations.common.NonNull;
+
+/**
+ * Abstract ColorValue implementation
+ *
+ * @see ColorValue
+ * @author junichi11
+ */
+public abstract class AbstractColorValue implements ColorValue {
+
+    private final int line;
+    private final int startOffset;
+    private final int endOffset;
+    private final String value;
+    private final ColorCodesProvider colorCodesProvider;
+
+    public AbstractColorValue(@NonNull ColorCodesProvider colorCodesProvider, @NonNull String value, int startOffset, int endOffset, int line) {
+        this.value = value;
+        this.startOffset = startOffset;
+        this.endOffset = endOffset;
+        this.line = line;
+        this.colorCodesProvider = colorCodesProvider;
+    }
+
+    @Override
+    public int getLine() {
+        return line;
+    }
+
+    @Override
+    public int getStartOffset() {
+        return startOffset;
+    }
+
+    @Override
+    public int getEndOffset() {
+        return endOffset;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public Color getColor() {
+        return ColorsUtils.decode(value);
+    }
+
+    @Override
+    public ColorCodesProvider getColorCodesProvider() {
+        return colorCodesProvider;
+    }
+
+}

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/ColorCodesProvider.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/ColorCodesProvider.java
@@ -30,10 +30,21 @@ public interface ColorCodesProvider {
     /**
      * is Mime Type supported by this provider
      *
+     * @param document current document, e.g.
+     * CompletionUtil.getPrimaryFile(Document)
      * @param mimeType Mime Type
      * @return true if supported
      */
-    public boolean isMimeTypeSupported(String mimeType);
+    public boolean isMimeTypeSupported(Document document, String mimeType);
+
+    /**
+     * Disable JColorChooser dialog on user click. For ColorValue created for
+     * variable from another file
+     *
+     * @param colorValue
+     * @return
+     */
+    public boolean isColorEditable(ColorValue colorValue);
 
     /**
      * is this provider enabled
@@ -45,10 +56,12 @@ public interface ColorCodesProvider {
     /**
      * can provider resolve variables for the Mime Type
      *
+     * @param document current document, e.g.
+     * CompletionUtil.getPrimaryFile(Document)
      * @param mimeType Mime Type
      * @return true if supported
      */
-    public boolean isResolveVariablesSupported(String mimeType);
+    public boolean isResolveVariablesSupported(Document document, String mimeType);
 
     /**
      * parse variables

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/ColorCodesProvider.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/ColorCodesProvider.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 arsi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.junichi11.netbeans.modules.color.codes.preview.colors.model;
+
+import java.awt.Color;
+import java.util.List;
+import java.util.Map;
+import javax.swing.text.Document;
+
+/**
+ * @ServiceProvider add Language implementation to netbeans-color-codes-preview
+ * plugin
+ * @author arsi
+ */
+public interface ColorCodesProvider {
+
+    /**
+     * is Mime Type supported by this provider
+     *
+     * @param mimeType Mime Type
+     * @return true if supported
+     */
+    public boolean isMimeTypeSupported(String mimeType);
+
+    /**
+     * is this provider enabled
+     *
+     * @return true if enabled
+     */
+    public boolean isProviderEnabled();
+
+    /**
+     * can provider resolve variables for the Mime Type
+     *
+     * @param mimeType Mime Type
+     * @return true if supported
+     */
+    public boolean isResolveVariablesSupported(String mimeType);
+
+    /**
+     * parse variables
+     *
+     * @param document current document, e.g.
+     * CompletionUtil.getPrimaryFile(Document)
+     * @param mimeType Mime Type
+     * @param line string to parse
+     * @param variables lineNumber to store to ColorValue
+     * @param colorValues List to add created ColorValue. Before adding new
+     * ColorValue, check if list containt ColorValue on same line, startoffset
+     * and endoffset
+     */
+    public void checkVariables(Document document, String mimeType, String line, Map<String, List<ColorValue>> variables, List<ColorValue> colorValues);
+
+    /**
+     * Parse line and add parsed colors to List colorValues
+     *
+     * @param document current document, e.g.
+     * CompletionUtil.getPrimaryFile(Document)
+     * @param mimeType Mime Type
+     * @param line string to parse
+     * @param lineNumber lineNumber to store to ColorValue
+     * @param colorValues List to add created ColorValue. Before adding new
+     * ColorValue, check if list containt ColorValue on same line, startoffset
+     * and endoffset
+     */
+    public void addAllColorValues(Document document, String mimeType, String line, int lineNumber, List<ColorValue> colorValues);
+
+    /**
+     * Return text for new color
+     *
+     * @param newColor Color selected by user
+     * @param originalColor original ColorValue
+     * @return text for new color
+     */
+    public String toFormattedString(Color newColor, ColorValue originalColor);
+
+}

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/ColorValue.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/ColorValue.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 junichi11.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.junichi11.netbeans.modules.color.codes.preview.colors.model;
+
+import java.awt.Color;
+
+/**
+ * Color value record
+ *
+ * @author junichi11
+ */
+public interface ColorValue {
+
+    Color getColor();
+
+    int getEndOffset();
+
+    int getLine();
+
+    int getStartOffset();
+
+    <E extends Enum<E>> E getType();
+
+    String getValue();
+
+    ColorCodesProvider getColorCodesProvider();
+
+}

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/impl/DefaultColorCodesProvider.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/impl/DefaultColorCodesProvider.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 junichi11.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.junichi11.netbeans.modules.color.codes.preview.colors.model.impl;
+
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.options.ColorCodesPreviewOptions;
+import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorsUtils;
+import java.awt.Color;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.swing.text.Document;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ *
+ * @author arsi
+ */
+@ServiceProvider(service = ColorCodesProvider.class, position = 0)
+public class DefaultColorCodesProvider implements ColorCodesProvider {
+
+    private static final Pattern CSS_VARIABLE_PATTERN = Pattern.compile("(?<var>[\\$@][^ ]+)\\s*:\\s*(?<value>).+\\s*;"); // NOI18N
+
+    @Override
+    public boolean isMimeTypeSupported(String mimeType) {
+        return mimeType.matches(ColorCodesPreviewOptions.getInstance().getMimeTypeRegex());
+    }
+
+    @Override
+    public boolean isProviderEnabled() {
+        return true;
+    }
+
+    @Override
+    public void addAllColorValues(Document document, String mimeType, String line, int lineNumber, List<ColorValue> colorValues) {
+        colorValues.addAll(ColorsUtils.getHexColorCodes(this, line, lineNumber));
+        colorValues.addAll(ColorsUtils.getCssIntRGBs(this, line, lineNumber));
+        colorValues.addAll(ColorsUtils.getCssIntRGBAs(this, line, lineNumber));
+        colorValues.addAll(ColorsUtils.getCssPercentRGBs(this, line, lineNumber));
+        colorValues.addAll(ColorsUtils.getCssPercentRGBAs(this, line, lineNumber));
+        colorValues.addAll(ColorsUtils.getCssHSLs(this, line, lineNumber));
+        colorValues.addAll(ColorsUtils.getCssHSLAs(this, line, lineNumber));
+        ColorCodesPreviewOptions options = ColorCodesPreviewOptions.getInstance();
+        if (options.useNamedColors()) {
+            colorValues.addAll(ColorsUtils.getNamedColors(this, line, lineNumber));
+        }
+    }
+
+    @Override
+    public boolean isResolveVariablesSupported(String mimeType) {
+        return resolveCssVariables(mimeType);
+    }
+
+    private boolean resolveCssVariables(String mimeType) {
+        return isLessOrSass(mimeType)
+                && ColorCodesPreviewOptions.getInstance().resolveCssVariables();
+    }
+
+    private boolean isLessOrSass(String mimeType) {
+        return "text/less".equals(mimeType) || "text/scss".equals(mimeType); // NOI18N
+    }
+
+    @Override
+    public void checkVariables(Document document, String mimeType, String line, Map<String, List<ColorValue>> cssVariables, List<ColorValue> colorValues) {
+        if (!isLessOrSass(mimeType)) {
+            return;
+        }
+
+        Matcher matcher = CSS_VARIABLE_PATTERN.matcher(line);
+        if (matcher.find()) {
+            String variable = matcher.group("var"); // NOI18N
+            if (variable != null) {
+                cssVariables.put(variable, colorValues);
+            }
+        } else {
+            final String l = line;
+            Map<Integer, String> map = new HashMap<>();
+            cssVariables.forEach((String var, List<ColorValue> colors) -> {
+                if (l.contains(var)) {
+                    int indexOfVar = l.indexOf(var);
+                    int offsetBehindVariableName = indexOfVar + var.length();
+                    if (offsetBehindVariableName < l.length()) {
+                        // e.g. when searche $green, ignore $green1, $green2,...
+                        char c = l.charAt(offsetBehindVariableName);
+                        if (c == ' ' || c == ';') {
+                            map.put(indexOfVar, var);
+                        }
+                    }
+                }
+            });
+            List<Integer> offsetNumbers = new ArrayList<>(map.keySet());
+            Collections.sort(offsetNumbers);
+            offsetNumbers.forEach(offset -> colorValues.addAll(cssVariables.get(map.get(offset))));
+        }
+    }
+
+    @Override
+    public String toFormattedString(Color newColor, ColorValue originalColor) {
+        return ColorsUtils.toFormattedString(newColor, originalColor.getType());
+    }
+
+}

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/impl/DefaultColorCodesProvider.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/impl/DefaultColorCodesProvider.java
@@ -40,12 +40,17 @@ public class DefaultColorCodesProvider implements ColorCodesProvider {
     private static final Pattern CSS_VARIABLE_PATTERN = Pattern.compile("(?<var>[\\$@][^ ]+)\\s*:\\s*(?<value>).+\\s*;"); // NOI18N
 
     @Override
-    public boolean isMimeTypeSupported(String mimeType) {
+    public boolean isMimeTypeSupported(Document document, String mimeType) {
         return mimeType.matches(ColorCodesPreviewOptions.getInstance().getMimeTypeRegex());
     }
 
     @Override
     public boolean isProviderEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isColorEditable(ColorValue colorValue) {
         return true;
     }
 
@@ -65,7 +70,7 @@ public class DefaultColorCodesProvider implements ColorCodesProvider {
     }
 
     @Override
-    public boolean isResolveVariablesSupported(String mimeType) {
+    public boolean isResolveVariablesSupported(Document document, String mimeType) {
         return resolveCssVariables(mimeType);
     }
 

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/impl/JavaColorCodesProvider.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/impl/JavaColorCodesProvider.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2019 arsi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.junichi11.netbeans.modules.color.codes.preview.colors.model.impl;
+
+import com.junichi11.netbeans.modules.color.codes.preview.colors.JavaIntRGBColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorValue;
+import java.awt.Color;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.swing.text.Document;
+import org.openide.util.lookup.ServiceProvider;
+
+/**
+ * Supported colors: new Color[]{Color.blue, new Color(153, 255, 0)}; new
+ * Color(0, 0, 0); Color.CYAN;
+ *
+ * @author arsi
+ */
+@ServiceProvider(service = ColorCodesProvider.class)
+public class JavaColorCodesProvider implements ColorCodesProvider {
+
+    private static final String RGB_VALUE_FORMAT = "Color(%s, %s, %s)"; // NOI18N
+    private static final Logger LOGGER = Logger.getLogger(JavaColorCodesProvider.class.getName());
+
+    @Override
+    public boolean isMimeTypeSupported(String mimeType) {
+        return "text/x-java".equals(mimeType);
+    }
+
+    @Override
+    public boolean isProviderEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean isResolveVariablesSupported(String mimeType) {
+        return false;
+    }
+
+    @Override
+    public void checkVariables(Document document, String mimeType, String line, Map<String, List<ColorValue>> variables, List<ColorValue> colorValues) {
+    }
+
+    @Override
+    public void addAllColorValues(Document document, String mimeType, String line, int lineNumber, List<ColorValue> colorValues) {
+        if ((line.contains("Color.") || line.contains("new Color(")) && !line.contains("import")) {
+            int index = 0;
+            while ((index = line.indexOf("Color.", index + 1)) >= 0) {
+                findStdColor(colorValues, "BLACK", Color.BLACK, line, index, lineNumber);
+                findStdColor(colorValues, "BLUE", Color.BLUE, line, index, lineNumber);
+                findStdColor(colorValues, "CYAN", Color.CYAN, line, index, lineNumber);
+                findStdColor(colorValues, "DARK_GRAY", Color.DARK_GRAY, line, index, lineNumber);
+                findStdColor(colorValues, "GRAY", Color.GRAY, line, index, lineNumber);
+                findStdColor(colorValues, "GREEN", Color.GREEN, line, index, lineNumber);
+                findStdColor(colorValues, "LIGHT_GRAY", Color.LIGHT_GRAY, line, index, lineNumber);
+                findStdColor(colorValues, "MAGENTA", Color.MAGENTA, line, index, lineNumber);
+                findStdColor(colorValues, "ORANGE", Color.ORANGE, line, index, lineNumber);
+                findStdColor(colorValues, "PINK", Color.PINK, line, index, lineNumber);
+                findStdColor(colorValues, "RED", Color.RED, line, index, lineNumber);
+                findStdColor(colorValues, "WHITE", Color.WHITE, line, index, lineNumber);
+                findStdColor(colorValues, "YELLOW", Color.YELLOW, line, index, lineNumber);
+
+                findStdColor(colorValues, "black", Color.black, line, index, lineNumber);
+                findStdColor(colorValues, "blue", Color.blue, line, index, lineNumber);
+                findStdColor(colorValues, "cyan", Color.cyan, line, index, lineNumber);
+                findStdColor(colorValues, "darkGray", Color.darkGray, line, index, lineNumber);
+                findStdColor(colorValues, "gray", Color.gray, line, index, lineNumber);
+                findStdColor(colorValues, "green", Color.green, line, index, lineNumber);
+                findStdColor(colorValues, "lightGray", Color.lightGray, line, index, lineNumber);
+                findStdColor(colorValues, "magenta", Color.magenta, line, index, lineNumber);
+                findStdColor(colorValues, "orange", Color.orange, line, index, lineNumber);
+                findStdColor(colorValues, "pink", Color.pink, line, index, lineNumber);
+                findStdColor(colorValues, "red", Color.red, line, index, lineNumber);
+                findStdColor(colorValues, "white", Color.white, line, index, lineNumber);
+                findStdColor(colorValues, "yellow", Color.yellow, line, index, lineNumber);
+            }
+            index = 0;
+            while ((index = line.indexOf("new Color(", index + 1)) >= 0) {
+                try {
+                    int start = index;
+                    index += "new Color(".length();
+                    int end = line.indexOf(')', index);
+                    String data = line.substring(index, end);
+                    Integer tmp[] = new Integer[5];
+                    int cnt = 0;
+                    for (StringTokenizer stringTokenizer = new StringTokenizer(data, ",", false); stringTokenizer.hasMoreTokens();) {
+                        String token = stringTokenizer.nextToken();
+                        try {
+                            tmp[cnt++] = new Integer(token.replaceAll(" ", ""));
+                        } catch (NumberFormatException numberFormatException) {
+                            numberFormatException.printStackTrace();
+                        }
+                    }
+                    if (cnt == 3) {
+                        colorValues.add(new JavaIntRGBColorValue(this, line.substring(start, end + 1), start, end + 1, lineNumber, tmp[0], tmp[1], tmp[2]));
+                    }
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Java color parser exception.", e); // NOI18N
+                }
+            }
+
+        }
+    }
+
+    private void findStdColor(List<ColorValue> colorValues, String color, Color cCode, String line, int index, int lineNumber) {
+        int start = index;
+        index = index + 6;
+        String sub = line.substring(index);
+        if (sub.startsWith(color)) {
+            colorValues.add(new JavaIntRGBColorValue(this, "Color." + color, start, start + 6 + color.length(), lineNumber, cCode.getRed(), cCode.getGreen(), cCode.getBlue()));
+        }
+
+    }
+
+    public static String RGBIntValueString(Color color) {
+        return String.format(RGB_VALUE_FORMAT, color.getRed(), color.getGreen(), color.getBlue());
+    }
+
+    @Override
+    public String toFormattedString(Color newColor, ColorValue originalColor) {
+        String standardJavaColor = getStandardJavaColor(newColor);
+        if (standardJavaColor != null) {
+            return standardJavaColor;
+        }
+        return "new " + RGBIntValueString(newColor);
+    }
+
+    private String getStandardJavaColor(Color selectedColor) {
+        if (Color.black.equals(selectedColor)) {
+            return "Color.black";
+        } else if (Color.blue.equals(selectedColor)) {
+            return "Color.blue";
+        } else if (Color.cyan.equals(selectedColor)) {
+            return "Color.cyan";
+        } else if (Color.darkGray.equals(selectedColor)) {
+            return "Color.darkGray";
+        } else if (Color.gray.equals(selectedColor)) {
+            return "Color.gray";
+        } else if (Color.green.equals(selectedColor)) {
+            return "Color.green";
+        } else if (Color.lightGray.equals(selectedColor)) {
+            return "Color.lightGray";
+        } else if (Color.magenta.equals(selectedColor)) {
+            return "Color.magenta";
+        } else if (Color.orange.equals(selectedColor)) {
+            return "Color.orange";
+        } else if (Color.pink.equals(selectedColor)) {
+            return "Color.pink";
+        } else if (Color.red.equals(selectedColor)) {
+            return "Color.red";
+        } else if (Color.white.equals(selectedColor)) {
+            return "Color.white";
+        } else if (Color.yellow.equals(selectedColor)) {
+            return "Color.yellow";
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/impl/JavaColorCodesProvider.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/colors/model/impl/JavaColorCodesProvider.java
@@ -40,7 +40,7 @@ public class JavaColorCodesProvider implements ColorCodesProvider {
     private static final Logger LOGGER = Logger.getLogger(JavaColorCodesProvider.class.getName());
 
     @Override
-    public boolean isMimeTypeSupported(String mimeType) {
+    public boolean isMimeTypeSupported(Document document, String mimeType) {
         return "text/x-java".equals(mimeType);
     }
 
@@ -50,7 +50,12 @@ public class JavaColorCodesProvider implements ColorCodesProvider {
     }
 
     @Override
-    public boolean isResolveVariablesSupported(String mimeType) {
+    public boolean isColorEditable(ColorValue colorValue) {
+        return false;
+    }
+
+    @Override
+    public boolean isResolveVariablesSupported(Document document, String mimeType) {
         return false;
     }
 

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/ui/ColorCodesPanel.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/ui/ColorCodesPanel.java
@@ -15,7 +15,7 @@
  */
 package com.junichi11.netbeans.modules.color.codes.preview.ui;
 
-import com.junichi11.netbeans.modules.color.codes.preview.colors.ColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorValue;
 import com.junichi11.netbeans.modules.color.codes.preview.utils.ColorsUtils;
 import java.awt.Color;
 import java.awt.Font;
@@ -97,7 +97,7 @@ public class ColorCodesPanel extends JComponent {
                                 try {
                                     int removeStart = lineOffset + startOffset;
                                     document.remove(removeStart, endOffset - startOffset);
-                                    document.insertString(removeStart, ColorsUtils.toFormattedString(selectedColor, colorValue.getType()), null);
+                                    document.insertString(removeStart, colorValue.getColorCodesProvider().toFormattedString(selectedColor, colorValue), null);
                                 } catch (BadLocationException ex) {
                                     LOGGER.log(Level.WARNING, ex.getMessage());
                                 }

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/ui/ColorCodesPanel.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/ui/ColorCodesPanel.java
@@ -67,6 +67,9 @@ public class ColorCodesPanel extends JComponent {
                 @Override
                 public void mouseClicked(MouseEvent e) {
                     // show dialog
+                    if (!colorValue.getColorCodesProvider().isColorEditable(colorValue)) {
+                        return;
+                    }
                     final Color selectedColor = JColorChooser.showDialog(
                             ColorCodesPanel.this,
                             Bundle.ColorCodesPanel_colorChooser_title(),

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/ui/DrawingPanel.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/ui/DrawingPanel.java
@@ -163,7 +163,7 @@ public final class DrawingPanel extends JPanel implements DocumentListener, Pref
             int clipEndY = clip.y + clip.height;
             boolean resolveVariables = false;
             for (ColorCodesProvider provider : providers) {
-                if (provider.isProviderEnabled() && provider.isResolveVariablesSupported(mimeType)) {
+                if (provider.isProviderEnabled() && provider.isResolveVariablesSupported(document, mimeType)) {
                     resolveVariables = true;
                 }
             }
@@ -194,7 +194,7 @@ public final class DrawingPanel extends JPanel implements DocumentListener, Pref
                     List<ColorValue> colorValues = new ArrayList<>();
 
                     for (ColorCodesProvider provider : providers) {
-                        if (provider.isProviderEnabled() && provider.isMimeTypeSupported(mimeType)) {
+                        if (provider.isProviderEnabled() && provider.isMimeTypeSupported(document, mimeType)) {
                             provider.addAllColorValues(document, mimeType, line, -1, colorValues);
                         }
                     }
@@ -202,7 +202,7 @@ public final class DrawingPanel extends JPanel implements DocumentListener, Pref
 
                     // for sass and less variables
                     for (ColorCodesProvider provider : providers) {
-                        if (provider.isProviderEnabled() && provider.isResolveVariablesSupported(mimeType)) {
+                        if (provider.isProviderEnabled() && provider.isResolveVariablesSupported(document, mimeType)) {
                             provider.checkVariables(document, mimeType, line, cssVariables, colorValues);
                         }
                     }
@@ -325,7 +325,7 @@ public final class DrawingPanel extends JPanel implements DocumentListener, Pref
         if (mimeType != null) {
             Collection<? extends ColorCodesProvider> providers = Lookup.getDefault().lookupAll(ColorCodesProvider.class);
             for (ColorCodesProvider provider : providers) {
-                if (provider.isProviderEnabled() && provider.isMimeTypeSupported(mimeType)) {
+                if (provider.isProviderEnabled() && provider.isMimeTypeSupported(document, mimeType)) {
                     return true;
                 }
             }
@@ -367,7 +367,7 @@ public final class DrawingPanel extends JPanel implements DocumentListener, Pref
         String mimeType = NbEditorUtilities.getMimeType(textComponent);
         List<ColorValue> colorValues = new ArrayList<>();
         for (ColorCodesProvider provider : providers) {
-            if (provider.isProviderEnabled() && provider.isMimeTypeSupported(mimeType)) {
+            if (provider.isProviderEnabled() && provider.isMimeTypeSupported(document, mimeType)) {
                 provider.addAllColorValues(document, mimeType, lineText, line, colorValues);
             }
         }

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/ui/PopupWindow.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/ui/PopupWindow.java
@@ -15,7 +15,7 @@
  */
 package com.junichi11.netbeans.modules.color.codes.preview.ui;
 
-import com.junichi11.netbeans.modules.color.codes.preview.colors.ColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorValue;
 import java.awt.AWTEvent;
 import java.awt.Component;
 import java.awt.Point;

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/utils/ColorType.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/utils/ColorType.java
@@ -22,7 +22,6 @@ import java.util.regex.Pattern;
  * @author junichi11
  */
 public enum ColorType {
-    CUSTOM("CUSTOM"),
     HEX("#(?<codenumber>[0-9a-fA-F]{6,}|[0-9a-fA-F]{3,})"), // NOI18N
     CSS_INT_RGB(String.format(ColorType.CSS_RGB_FORMAT, ColorType.INT_RGB_VALUE_FORMAT, ColorType.INT_RGB_VALUE_FORMAT, ColorType.INT_RGB_VALUE_FORMAT)),
     CSS_PERCENT_RGB(String.format(ColorType.CSS_RGB_FORMAT, ColorType.PERCENT_VALUE_FORMAT, ColorType.PERCENT_VALUE_FORMAT, ColorType.PERCENT_VALUE_FORMAT)),

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/utils/ColorType.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/utils/ColorType.java
@@ -22,6 +22,7 @@ import java.util.regex.Pattern;
  * @author junichi11
  */
 public enum ColorType {
+    CUSTOM("CUSTOM"),
     HEX("#(?<codenumber>[0-9a-fA-F]{6,}|[0-9a-fA-F]{3,})"), // NOI18N
     CSS_INT_RGB(String.format(ColorType.CSS_RGB_FORMAT, ColorType.INT_RGB_VALUE_FORMAT, ColorType.INT_RGB_VALUE_FORMAT, ColorType.INT_RGB_VALUE_FORMAT)),
     CSS_PERCENT_RGB(String.format(ColorType.CSS_RGB_FORMAT, ColorType.PERCENT_VALUE_FORMAT, ColorType.PERCENT_VALUE_FORMAT, ColorType.PERCENT_VALUE_FORMAT)),

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/utils/ColorsUtils.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/utils/ColorsUtils.java
@@ -15,15 +15,16 @@
  */
 package com.junichi11.netbeans.modules.color.codes.preview.utils;
 
-import com.junichi11.netbeans.modules.color.codes.preview.colors.CssIntRGBColorValue;
-import com.junichi11.netbeans.modules.color.codes.preview.colors.CssPercentRGBColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorValue;
 import com.junichi11.netbeans.modules.color.codes.preview.colors.CssHSLAColorValue;
-import com.junichi11.netbeans.modules.color.codes.preview.colors.ColorValue;
-import com.junichi11.netbeans.modules.color.codes.preview.colors.CssIntRGBAColorValue;
 import com.junichi11.netbeans.modules.color.codes.preview.colors.CssHSLColorValue;
-import com.junichi11.netbeans.modules.color.codes.preview.colors.HexColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.CssIntRGBAColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.CssIntRGBColorValue;
 import com.junichi11.netbeans.modules.color.codes.preview.colors.CssPercentRGBAColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.CssPercentRGBColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.HexColorValue;
 import com.junichi11.netbeans.modules.color.codes.preview.colors.NamedColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider;
 import java.awt.Color;
 import java.math.BigDecimal;
 import java.text.NumberFormat;
@@ -34,8 +35,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.netbeans.api.annotations.common.CheckForNull;
+import org.netbeans.api.annotations.common.NonNull;
 
 /**
  *
@@ -264,7 +265,7 @@ public final class ColorsUtils {
      * @param line target text
      * @return hex color codes
      */
-    public static List<ColorValue> getHexColorCodes(String line, int lineNumber) {
+    public static List<ColorValue> getHexColorCodes(@NonNull ColorCodesProvider colorCodesProvider, String line, int lineNumber) {
         Matcher matcher = getColorMatcher(line, ColorType.HEX);
         ArrayList<ColorValue> colorValues = new ArrayList<>();
         while (matcher.find()) {
@@ -276,7 +277,7 @@ public final class ColorsUtils {
             }
 
             if (hexCode.length() == 6) {
-                ColorValue colorValue = new HexColorValue(String.format("#%s", hexCode), matcher.start(), matcher.end(), lineNumber); // NOI18N
+                ColorValue colorValue = new HexColorValue(colorCodesProvider, String.format("#%s", hexCode), matcher.start(), matcher.end(), lineNumber); // NOI18N
                 colorValues.add(colorValue);
             }
 
@@ -290,12 +291,12 @@ public final class ColorsUtils {
      * @param line target text
      * @return named colors
      */
-    public static List<ColorValue> getNamedColors(String line, int lineNumber) {
+    public static List<ColorValue> getNamedColors(@NonNull ColorCodesProvider colorCodesProvider, String line, int lineNumber) {
         Matcher matcher = getColorMatcher(line, ColorType.NAMED_COLORS);
         ArrayList<ColorValue> colorValues = new ArrayList<>();
         while (matcher.find()) {
             final String namedColor = matcher.group(0);
-            ColorValue colorValue = new NamedColorValue(namedColor, matcher.start(), matcher.end(), lineNumber);
+            ColorValue colorValue = new NamedColorValue(colorCodesProvider, namedColor, matcher.start(), matcher.end(), lineNumber);
             colorValues.add(colorValue);
         }
         return colorValues;
@@ -323,8 +324,8 @@ public final class ColorsUtils {
      * @param line a line
      * @return RGB codes
      */
-    public static List<ColorValue> getCssIntRGBs(String line, int lineNumber) {
-        return getCssColorValues(line, lineNumber, ColorType.CSS_INT_RGB);
+    public static List<ColorValue> getCssIntRGBs(@NonNull ColorCodesProvider colorCodesProvider, String line, int lineNumber) {
+        return getCssColorValues(colorCodesProvider, line, lineNumber, ColorType.CSS_INT_RGB);
     }
 
     /**
@@ -333,8 +334,8 @@ public final class ColorsUtils {
      * @param line a line
      * @return RGB color values
      */
-    public static List<ColorValue> getCssPercentRGBs(String line, int lineNumber) {
-        return getCssColorValues(line, lineNumber, ColorType.CSS_PERCENT_RGB);
+    public static List<ColorValue> getCssPercentRGBs(@NonNull ColorCodesProvider colorCodesProvider, String line, int lineNumber) {
+        return getCssColorValues(colorCodesProvider, line, lineNumber, ColorType.CSS_PERCENT_RGB);
     }
 
     /**
@@ -359,8 +360,8 @@ public final class ColorsUtils {
      * @param line a line
      * @return RGBA color values
      */
-    public static List<ColorValue> getCssIntRGBAs(String line, int lineNumber) {
-        return getCssColorValues(line, lineNumber, ColorType.CSS_INT_RGBA);
+    public static List<ColorValue> getCssIntRGBAs(@NonNull ColorCodesProvider colorCodesProvider, String line, int lineNumber) {
+        return getCssColorValues(colorCodesProvider, line, lineNumber, ColorType.CSS_INT_RGBA);
     }
 
     /**
@@ -369,8 +370,8 @@ public final class ColorsUtils {
      * @param line a line
      * @return RGBA color values
      */
-    public static List<ColorValue> getCssPercentRGBAs(String line, int lineNumber) {
-        return getCssColorValues(line, lineNumber, ColorType.CSS_PERCENT_RGBA);
+    public static List<ColorValue> getCssPercentRGBAs(@NonNull ColorCodesProvider colorCodesProvider, String line, int lineNumber) {
+        return getCssColorValues(colorCodesProvider, line, lineNumber, ColorType.CSS_PERCENT_RGBA);
     }
 
     /**
@@ -379,8 +380,8 @@ public final class ColorsUtils {
      * @param line a line
      * @return HSL ColorValues
      */
-    public static List<ColorValue> getCssHSLs(String line, int lineNumber) {
-        return getCssColorValues(line, lineNumber, ColorType.CSS_HSL);
+    public static List<ColorValue> getCssHSLs(@NonNull ColorCodesProvider colorCodesProvider, String line, int lineNumber) {
+        return getCssColorValues(colorCodesProvider, line, lineNumber, ColorType.CSS_HSL);
     }
 
     /**
@@ -389,8 +390,8 @@ public final class ColorsUtils {
      * @param line a line
      * @return HSLA ColorValues
      */
-    public static List<ColorValue> getCssHSLAs(String line, int lineNumber) {
-        return getCssColorValues(line, lineNumber, ColorType.CSS_HSLA);
+    public static List<ColorValue> getCssHSLAs(@NonNull ColorCodesProvider colorCodesProvider, String line, int lineNumber) {
+        return getCssColorValues(colorCodesProvider, line, lineNumber, ColorType.CSS_HSLA);
     }
 
     /**
@@ -401,13 +402,13 @@ public final class ColorsUtils {
      * @param type ColorType
      * @return ColorValues
      */
-    private static List<ColorValue> getCssColorValues(String line, int lineNumber, ColorType type) {
+    private static List<ColorValue> getCssColorValues(@NonNull ColorCodesProvider colorCodesProvider, String line, int lineNumber, ColorType type) {
         Matcher matcher = getColorMatcher(line, type);
         ArrayList<ColorValue> colorCodes = new ArrayList<>();
         String groupName = getCssColorGroupName(type);
         while (matcher.find()) {
             final String colorCode = matcher.group(groupName);
-            ColorValue colorValue = createCssColorValue(colorCode, matcher.start(), matcher.end(), lineNumber, type);
+            ColorValue colorValue = createCssColorValue(colorCodesProvider, colorCode, matcher.start(), matcher.end(), lineNumber, type);
             if (colorValue != null) {
                 colorCodes.add(colorValue);
             }
@@ -438,20 +439,20 @@ public final class ColorsUtils {
         }
     }
 
-    private static ColorValue createCssColorValue(String value, int startOffset, int endOffset, int lineNumber, ColorType type) {
+    private static ColorValue createCssColorValue(@NonNull ColorCodesProvider colorCodesProvider, String value, int startOffset, int endOffset, int lineNumber, ColorType type) {
         switch (type) {
             case CSS_INT_RGB:
-                return new CssIntRGBColorValue(value, startOffset, endOffset, lineNumber);
+                return new CssIntRGBColorValue(colorCodesProvider, value, startOffset, endOffset, lineNumber);
             case CSS_INT_RGBA:
-                return new CssIntRGBAColorValue(value, startOffset, endOffset, lineNumber);
+                return new CssIntRGBAColorValue(colorCodesProvider, value, startOffset, endOffset, lineNumber);
             case CSS_PERCENT_RGB:
-                return new CssPercentRGBColorValue(value, startOffset, endOffset, lineNumber);
+                return new CssPercentRGBColorValue(colorCodesProvider, value, startOffset, endOffset, lineNumber);
             case CSS_PERCENT_RGBA:
-                return new CssPercentRGBAColorValue(value, startOffset, endOffset, lineNumber);
+                return new CssPercentRGBAColorValue(colorCodesProvider, value, startOffset, endOffset, lineNumber);
             case CSS_HSL:
-                return new CssHSLColorValue(value, startOffset, endOffset, lineNumber);
+                return new CssHSLColorValue(colorCodesProvider, value, startOffset, endOffset, lineNumber);
             case CSS_HSLA:
-                return new CssHSLAColorValue(value, startOffset, endOffset, lineNumber);
+                return new CssHSLAColorValue(colorCodesProvider, value, startOffset, endOffset, lineNumber);
             default:
                 throw new AssertionError();
         }

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/utils/ColorsUtils.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/utils/ColorsUtils.java
@@ -15,7 +15,6 @@
  */
 package com.junichi11.netbeans.modules.color.codes.preview.utils;
 
-import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorValue;
 import com.junichi11.netbeans.modules.color.codes.preview.colors.CssHSLAColorValue;
 import com.junichi11.netbeans.modules.color.codes.preview.colors.CssHSLColorValue;
 import com.junichi11.netbeans.modules.color.codes.preview.colors.CssIntRGBAColorValue;
@@ -25,6 +24,7 @@ import com.junichi11.netbeans.modules.color.codes.preview.colors.CssPercentRGBCo
 import com.junichi11.netbeans.modules.color.codes.preview.colors.HexColorValue;
 import com.junichi11.netbeans.modules.color.codes.preview.colors.NamedColorValue;
 import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorValue;
 import java.awt.Color;
 import java.math.BigDecimal;
 import java.text.NumberFormat;

--- a/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/utils/JavaColorType.java
+++ b/src/main/java/com/junichi11/netbeans/modules/color/codes/preview/utils/JavaColorType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 junichi11.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.junichi11.netbeans.modules.color.codes.preview.utils;
+
+/**
+ *
+ * @author junichi11
+ */
+public enum JavaColorType {
+    JAVA_INT_RGB,
+
+}

--- a/src/main/nbm/manifest.mf
+++ b/src/main/nbm/manifest.mf
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Localizing-Bundle: com/junichi11/netbeans/modules/color/codes/preview/Bundle.properties
-
+OpenIDE-Module-Recommends: com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider

--- a/src/test/java/com/junichi11/netbeans/modules/color/codes/preview/utils/ColorsUtilsTest.java
+++ b/src/test/java/com/junichi11/netbeans/modules/color/codes/preview/utils/ColorsUtilsTest.java
@@ -15,7 +15,8 @@
  */
 package com.junichi11.netbeans.modules.color.codes.preview.utils;
 
-import com.junichi11.netbeans.modules.color.codes.preview.colors.ColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorValue;
+import com.junichi11.netbeans.modules.color.codes.preview.colors.model.impl.DefaultColorCodesProvider;
 import java.awt.Color;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -496,30 +497,31 @@ public class ColorsUtilsTest {
      */
     @Test
     public void testGetHexColorCodesColorValues() {
-        List<ColorValue> result = ColorsUtils.getHexColorCodes("#000000", 1);
+        DefaultColorCodesProvider provider = new DefaultColorCodesProvider();
+        List<ColorValue> result = ColorsUtils.getHexColorCodes(provider, "#000000", 1);
         Assert.assertEquals(1, result.size());
 
-        result = ColorsUtils.getHexColorCodes("#000", 1);
+        result = ColorsUtils.getHexColorCodes(provider, "#000", 1);
         Assert.assertEquals(1, result.size());
 
-        result = ColorsUtils.getHexColorCodes("hex#ffffffhex", 1);
+        result = ColorsUtils.getHexColorCodes(provider, "hex#ffffffhex", 1);
         Assert.assertEquals(1, result.size());
 
-        result = ColorsUtils.getHexColorCodes("hex#ffffff#000", 1);
+        result = ColorsUtils.getHexColorCodes(provider, "hex#ffffff#000", 1);
         Assert.assertEquals(2, result.size());
 
-        result = ColorsUtils.getHexColorCodes("hex #ffffff #000 #1", 1);
+        result = ColorsUtils.getHexColorCodes(provider, "hex #ffffff #000 #1", 1);
         Assert.assertEquals(2, result.size());
 
-        result = ColorsUtils.getHexColorCodes("#1", 1);
+        result = ColorsUtils.getHexColorCodes(provider, "#1", 1);
         Assert.assertEquals(0, result.size());
-        result = ColorsUtils.getHexColorCodes("#22", 1);
+        result = ColorsUtils.getHexColorCodes(provider, "#22", 1);
         Assert.assertEquals(0, result.size());
-        result = ColorsUtils.getHexColorCodes("#4444", 1);
+        result = ColorsUtils.getHexColorCodes(provider, "#4444", 1);
         Assert.assertEquals(0, result.size());
-        result = ColorsUtils.getHexColorCodes("#55555", 1);
+        result = ColorsUtils.getHexColorCodes(provider, "#55555", 1);
         Assert.assertEquals(0, result.size());
-        result = ColorsUtils.getHexColorCodes("#7777777", 1);
+        result = ColorsUtils.getHexColorCodes(provider, "#7777777", 1);
         Assert.assertEquals(0, result.size());
     }
 
@@ -549,19 +551,20 @@ public class ColorsUtilsTest {
      */
     @Test
     public void testGetCssIntRGBColorValues() {
-        List<ColorValue> result = ColorsUtils.getCssIntRGBs("rgb(0, 0, 0)", -1);
+        DefaultColorCodesProvider provider = new DefaultColorCodesProvider();
+        List<ColorValue> result = ColorsUtils.getCssIntRGBs(provider, "rgb(0, 0, 0)", -1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getCssIntRGBs("rgb(100 , 100 , 100)", 1);
+        result = ColorsUtils.getCssIntRGBs(provider, "rgb(100 , 100 , 100)", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getCssIntRGBs("rgb(255, 255, 255)", 1);
+        result = ColorsUtils.getCssIntRGBs(provider, "rgb(255, 255, 255)", 1);
         assertEquals(1, result.size());
 
-        result = ColorsUtils.getCssIntRGBs("rgb(255, 255, 255) rgb(0,0,0)", 1);
+        result = ColorsUtils.getCssIntRGBs(provider, "rgb(255, 255, 255) rgb(0,0,0)", 1);
         assertEquals(2, result.size());
 
-        result = ColorsUtils.getCssIntRGBs("test", 1);
+        result = ColorsUtils.getCssIntRGBs(provider, "test", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssIntRGBs("rgb(-1, 255, 255)", 1);
+        result = ColorsUtils.getCssIntRGBs(provider, "rgb(-1, 255, 255)", 1);
         assertEquals(0, result.size());
     }
 
@@ -570,23 +573,24 @@ public class ColorsUtilsTest {
      */
     @Test
     public void testGetCssPercentRGBColorValues() {
-        List<ColorValue> result = ColorsUtils.getCssPercentRGBs("rgb(0%, 0%, 0%)", -1);
+        DefaultColorCodesProvider provider = new DefaultColorCodesProvider();
+        List<ColorValue> result = ColorsUtils.getCssPercentRGBs(provider, "rgb(0%, 0%, 0%)", -1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getCssPercentRGBs("rgb(50% , 50% , 50%)", 1);
+        result = ColorsUtils.getCssPercentRGBs(provider, "rgb(50% , 50% , 50%)", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getCssPercentRGBs("rgb(100%, 100%, 100%)", 1);
+        result = ColorsUtils.getCssPercentRGBs(provider, "rgb(100%, 100%, 100%)", 1);
         assertEquals(1, result.size());
 
-        result = ColorsUtils.getCssPercentRGBs("rgb(100%, 100%, 100%) rgb(0%,0%,0%)", 1);
+        result = ColorsUtils.getCssPercentRGBs(provider, "rgb(100%, 100%, 100%) rgb(0%,0%,0%)", 1);
         assertEquals(2, result.size());
 
-        result = ColorsUtils.getCssPercentRGBs("test", 1);
+        result = ColorsUtils.getCssPercentRGBs(provider, "test", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssPercentRGBs("rgb(-1%, 100%, 100%)", 1);
+        result = ColorsUtils.getCssPercentRGBs(provider, "rgb(-1%, 100%, 100%)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssPercentRGBs("rgb(100, 100, 100)", 1);
+        result = ColorsUtils.getCssPercentRGBs(provider, "rgb(100, 100, 100)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssPercentRGBs("rgba(100%, 100%, 100%, 1)", 1);
+        result = ColorsUtils.getCssPercentRGBs(provider, "rgba(100%, 100%, 100%, 1)", 1);
         assertEquals(0, result.size());
     }
 
@@ -623,33 +627,34 @@ public class ColorsUtilsTest {
      */
     @Test
     public void testGetCssIntRGBAColorValues() {
-        List<ColorValue> result = ColorsUtils.getCssIntRGBAs("rgba(0, 0, 0, 0)", -1);
+        DefaultColorCodesProvider provider = new DefaultColorCodesProvider();
+        List<ColorValue> result = ColorsUtils.getCssIntRGBAs(provider, "rgba(0, 0, 0, 0)", -1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getCssIntRGBAs("rgba(100, 100, 100, 0.5)", 1);
+        result = ColorsUtils.getCssIntRGBAs(provider, "rgba(100, 100, 100, 0.5)", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getCssIntRGBAs("rgba(255, 255, 255, 1)", 1);
+        result = ColorsUtils.getCssIntRGBAs(provider, "rgba(255, 255, 255, 1)", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getCssIntRGBAs("rgba(255, 255, 255, 1)", 1);
+        result = ColorsUtils.getCssIntRGBAs(provider, "rgba(255, 255, 255, 1)", 1);
         assertEquals(1, result.size());
 
         // multiple values
-        result = ColorsUtils.getCssIntRGBAs("rgba(255, 255, 255, 0.1) rgba(0,0,0, 0.8)", 1);
+        result = ColorsUtils.getCssIntRGBAs(provider, "rgba(255, 255, 255, 0.1) rgba(0,0,0, 0.8)", 1);
         assertEquals(2, result.size());
-        result = ColorsUtils.getCssIntRGBAs("rgba(255, 255, 255, 1) test rgba(0,0,0, -1)", 1);
+        result = ColorsUtils.getCssIntRGBAs(provider, "rgba(255, 255, 255, 1) test rgba(0,0,0, -1)", 1);
         assertEquals(1, result.size());
 
         // no colors
-        result = ColorsUtils.getCssIntRGBAs("test", 1);
+        result = ColorsUtils.getCssIntRGBAs(provider, "test", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssIntRGBAs("rgba(-1, 255, 255, 1)", 1);
+        result = ColorsUtils.getCssIntRGBAs(provider, "rgba(-1, 255, 255, 1)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssIntRGBAs("rgba(0, 0, 0, 1.5)", 1);
+        result = ColorsUtils.getCssIntRGBAs(provider, "rgba(0, 0, 0, 1.5)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssIntRGBAs("rgba(0, 0, 0, -1)", 1);
+        result = ColorsUtils.getCssIntRGBAs(provider, "rgba(0, 0, 0, -1)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssIntRGBAs("rgba(0, 0, 0, 0.0)", 1);
+        result = ColorsUtils.getCssIntRGBAs(provider, "rgba(0, 0, 0, 0.0)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssIntRGBAs("rgba(0, 0, 0, 0.50)", 1);
+        result = ColorsUtils.getCssIntRGBAs(provider, "rgba(0, 0, 0, 0.50)", 1);
         assertEquals(0, result.size());
     }
 
@@ -658,35 +663,36 @@ public class ColorsUtilsTest {
      */
     @Test
     public void testGetCssPercentRGBAColorValues() {
-        List<ColorValue> result = ColorsUtils.getCssPercentRGBAs("rgba(0%, 0%, 0%, 0)", -1);
+        DefaultColorCodesProvider provider = new DefaultColorCodesProvider();
+        List<ColorValue> result = ColorsUtils.getCssPercentRGBAs(provider, "rgba(0%, 0%, 0%, 0)", -1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getCssPercentRGBAs("rgba(100%, 100%, 100%, 0.5)", 1);
+        result = ColorsUtils.getCssPercentRGBAs(provider, "rgba(100%, 100%, 100%, 0.5)", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getCssPercentRGBAs("rgba(100%, 100%, 100%, 1)", 1);
+        result = ColorsUtils.getCssPercentRGBAs(provider, "rgba(100%, 100%, 100%, 1)", 1);
         assertEquals(1, result.size());
 
         // multiple values
-        result = ColorsUtils.getCssPercentRGBAs("rgba(100%, 100%, 100%, 0.1) rgba(0%,0%,0%, 0.8)", 1);
+        result = ColorsUtils.getCssPercentRGBAs(provider, "rgba(100%, 100%, 100%, 0.1) rgba(0%,0%,0%, 0.8)", 1);
         assertEquals(2, result.size());
-        result = ColorsUtils.getCssPercentRGBAs("rgba(100%, 100%, 100%, 1) test rgba(0%,0%,0%, -1)", 1);
+        result = ColorsUtils.getCssPercentRGBAs(provider, "rgba(100%, 100%, 100%, 1) test rgba(0%,0%,0%, -1)", 1);
         assertEquals(1, result.size());
 
         // no colors
-        result = ColorsUtils.getCssPercentRGBAs("test", 1);
+        result = ColorsUtils.getCssPercentRGBAs(provider, "test", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssPercentRGBAs("rgba(-1%, 100%, 100%, 1)", 1);
+        result = ColorsUtils.getCssPercentRGBAs(provider, "rgba(-1%, 100%, 100%, 1)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssPercentRGBAs("rgba(0%, 0%, 0%, 1.5)", 1);
+        result = ColorsUtils.getCssPercentRGBAs(provider, "rgba(0%, 0%, 0%, 1.5)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssPercentRGBAs("rgba(0%, 0%, 0%, -1)", 1);
+        result = ColorsUtils.getCssPercentRGBAs(provider, "rgba(0%, 0%, 0%, -1)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssPercentRGBAs("rgba(0%, 0%, 0%, 0.0)", 1);
+        result = ColorsUtils.getCssPercentRGBAs(provider, "rgba(0%, 0%, 0%, 0.0)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssPercentRGBAs("rgba(0%, 0%, 0%, 0.50)", 1);
+        result = ColorsUtils.getCssPercentRGBAs(provider, "rgba(0%, 0%, 0%, 0.50)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssPercentRGBAs("rgba(0, 0, 0, 0.50)", 1);
+        result = ColorsUtils.getCssPercentRGBAs(provider, "rgba(0, 0, 0, 0.50)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssPercentRGBAs("rgb(0, 0, 0)", 1);
+        result = ColorsUtils.getCssPercentRGBAs(provider, "rgb(0, 0, 0)", 1);
         assertEquals(0, result.size());
     }
 
@@ -695,38 +701,39 @@ public class ColorsUtilsTest {
      */
     @Test
     public void testGetCssHSLColorValues() {
-        List<ColorValue> result = ColorsUtils.getCssHSLs("hsl(0, 0%, 0%)", -1);
+        DefaultColorCodesProvider provider = new DefaultColorCodesProvider();
+        List<ColorValue> result = ColorsUtils.getCssHSLs(provider, "hsl(0, 0%, 0%)", -1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getCssHSLs("hsl(180, 50%, 50%)", 1);
+        result = ColorsUtils.getCssHSLs(provider, "hsl(180, 50%, 50%)", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getCssHSLs("hsl(360, 100%, 100%)", 1);
+        result = ColorsUtils.getCssHSLs(provider, "hsl(360, 100%, 100%)", 1);
         assertEquals(1, result.size());
 
         // multiple values
-        result = ColorsUtils.getCssHSLs("hsl(0, 100%, 100%) hsl(0,0%,0%)", 1);
+        result = ColorsUtils.getCssHSLs(provider, "hsl(0, 100%, 100%) hsl(0,0%,0%)", 1);
         assertEquals(2, result.size());
-        result = ColorsUtils.getCssHSLs("hsl(-1, 100%, 100%) test hsl(0,0%,0%)", 1);
+        result = ColorsUtils.getCssHSLs(provider, "hsl(-1, 100%, 100%) test hsl(0,0%,0%)", 1);
         assertEquals(1, result.size());
 
         // no colors
-        result = ColorsUtils.getCssHSLs("test", 1);
+        result = ColorsUtils.getCssHSLs(provider, "test", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLs("hsl(-1, 100%, 100%)", 1);
+        result = ColorsUtils.getCssHSLs(provider, "hsl(-1, 100%, 100%)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLs("hsl(361, 100%, 100%)", 1);
+        result = ColorsUtils.getCssHSLs(provider, "hsl(361, 100%, 100%)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLs("hsl(0, -1%, 0%)", 1);
+        result = ColorsUtils.getCssHSLs(provider, "hsl(0, -1%, 0%)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLs("hsl(0, 101%, 0%)", 1);
+        result = ColorsUtils.getCssHSLs(provider, "hsl(0, 101%, 0%)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLs("hsl(0, 0%, -1%)", 1);
+        result = ColorsUtils.getCssHSLs(provider, "hsl(0, 0%, -1%)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLs("hsl(0, 0%, 101%)", 1);
+        result = ColorsUtils.getCssHSLs(provider, "hsl(0, 0%, 101%)", 1);
         assertEquals(0, result.size());
 
-        result = ColorsUtils.getCssHSLs("hsl(0, 0%, 0%, 0)", 1);
+        result = ColorsUtils.getCssHSLs(provider, "hsl(0, 0%, 0%, 0)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLs("hsla(0, 0%, 0%, 0)", 1);
+        result = ColorsUtils.getCssHSLs(provider, "hsla(0, 0%, 0%, 0)", 1);
         assertEquals(0, result.size());
     }
 
@@ -735,42 +742,43 @@ public class ColorsUtilsTest {
      */
     @Test
     public void testGetCssHSLAColorValues() {
-        List<ColorValue> result = ColorsUtils.getCssHSLAs("hsla(0, 0%, 0%, 0)", -1);
+        DefaultColorCodesProvider provider = new DefaultColorCodesProvider();
+        List<ColorValue> result = ColorsUtils.getCssHSLAs(provider, "hsla(0, 0%, 0%, 0)", -1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getCssHSLAs("hsla(180, 50%, 50%, 0.5)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsla(180, 50%, 50%, 0.5)", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getCssHSLAs("hsla(360, 100%, 100%, 1)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsla(360, 100%, 100%, 1)", 1);
         assertEquals(1, result.size());
 
         // multiple values
-        result = ColorsUtils.getCssHSLAs("hsla(0, 100%, 100%, 1) hsla(0,0%,0%, 0.8)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsla(0, 100%, 100%, 1) hsla(0,0%,0%, 0.8)", 1);
         assertEquals(2, result.size());
-        result = ColorsUtils.getCssHSLAs("hsla(180, 100%, 100%, -1) test hsla(0,0%,0%, 0)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsla(180, 100%, 100%, -1) test hsla(0,0%,0%, 0)", 1);
         assertEquals(1, result.size());
 
         // no colors
-        result = ColorsUtils.getCssHSLAs("test", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "test", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLAs("hsla(-1, 100%, 100%, 0)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsla(-1, 100%, 100%, 0)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLAs("hsla(361, 100%, 100%, 0)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsla(361, 100%, 100%, 0)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLAs("hsla(0, -1%, 0%, 0)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsla(0, -1%, 0%, 0)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLAs("hsla(0, 101%, 0%, 0)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsla(0, 101%, 0%, 0)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLAs("hsla(0, 0%, -1%, 0)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsla(0, 0%, -1%, 0)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLAs("hsla(0, 0%, 101%, 0)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsla(0, 0%, 101%, 0)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLAs("hsla(0, 0%, 100%, -0.1)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsla(0, 0%, 100%, -0.1)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLAs("hsla(0, 0%, 100%, 1.1)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsla(0, 0%, 100%, 1.1)", 1);
         assertEquals(0, result.size());
 
-        result = ColorsUtils.getCssHSLAs("hsla(0, 0%, 0%)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsla(0, 0%, 0%)", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getCssHSLAs("hsl(0, 0%, 0%)", 1);
+        result = ColorsUtils.getCssHSLAs(provider, "hsl(0, 0%, 0%)", 1);
         assertEquals(0, result.size());
     }
 
@@ -779,47 +787,48 @@ public class ColorsUtilsTest {
      */
     @Test
     public void testGetNamedColorValues() {
-        List<ColorValue> result = ColorsUtils.getNamedColors(" black ", -1);
+        DefaultColorCodesProvider provider = new DefaultColorCodesProvider();
+        List<ColorValue> result = ColorsUtils.getNamedColors(provider, " black ", -1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" BLACK ", 1);
+        result = ColorsUtils.getNamedColors(provider, " BLACK ", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" yellow ", 1);
+        result = ColorsUtils.getNamedColors(provider, " yellow ", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" green ", 1);
+        result = ColorsUtils.getNamedColors(provider, " green ", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" yellowgreen ", 1);
+        result = ColorsUtils.getNamedColors(provider, " yellowgreen ", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" greenyellow ", 1);
+        result = ColorsUtils.getNamedColors(provider, " greenyellow ", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" orangered ", 1);
+        result = ColorsUtils.getNamedColors(provider, " orangered ", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" red ", 1);
+        result = ColorsUtils.getNamedColors(provider, " red ", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" orange ", 1);
+        result = ColorsUtils.getNamedColors(provider, " orange ", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" mediumslateblue ", 1);
+        result = ColorsUtils.getNamedColors(provider, " mediumslateblue ", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" blue ", 1);
+        result = ColorsUtils.getNamedColors(provider, " blue ", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" mediumblue ", 1);
+        result = ColorsUtils.getNamedColors(provider, " mediumblue ", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" aquamarine ", 1);
+        result = ColorsUtils.getNamedColors(provider, " aquamarine ", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" aqua ", 1);
+        result = ColorsUtils.getNamedColors(provider, " aqua ", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(" aqua\"", 1);
+        result = ColorsUtils.getNamedColors(provider, " aqua\"", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(":red;", 1);
+        result = ColorsUtils.getNamedColors(provider, ":red;", 1);
         assertEquals(1, result.size());
-        result = ColorsUtils.getNamedColors(": red;", 1);
+        result = ColorsUtils.getNamedColors(provider, ": red;", 1);
         assertEquals(1, result.size());
 
-        result = ColorsUtils.getNamedColors(" green, yellow ", 1);
+        result = ColorsUtils.getNamedColors(provider, " green, yellow ", 1);
         assertEquals(2, result.size());
 
-        result = ColorsUtils.getNamedColors("invalidName", 1);
+        result = ColorsUtils.getNamedColors(provider, "invalidName", 1);
         assertEquals(0, result.size());
-        result = ColorsUtils.getNamedColors("white-space", 1);
+        result = ColorsUtils.getNamedColors(provider, "white-space", 1);
         assertEquals(0, result.size());
     }
 }


### PR DESCRIPTION
Added new interface `com.junichi11.netbeans.modules.color.codes.preview.colors.model.ColorCodesProvider`
for other languages implementations from other plugings to use as @ServiceProvider
And moved original code to `DefaultColorCodesProvider`

And basic java support for Color constants and int RGB values `JavaColorCodesProvider`:
![obrazok](https://user-images.githubusercontent.com/22594510/50682878-8f3a6200-1010-11e9-8580-1b6da08edb8e.png)
 